### PR TITLE
Fix text-ident issue

### DIFF
--- a/WordElement.css
+++ b/WordElement.css
@@ -1,9 +1,10 @@
 span[wordology_word]
 {
 	display: inline-block;
+	position: relative;
 	padding: 0px;
 	border-radius: 0px;
-	position: relative;
+	text-indent: initial;	
 }
 span[wordology_word="hidden"]
 {


### PR DESCRIPTION
I've set the ```text-indent``` property to ```initial``` so that the previous value will only be applied to the first word in the paragraph.
This fixes #3.